### PR TITLE
Added fix_com=True and fix_orientation=True to default qcel.Molecule …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Updated `black`.
+- Added `fix_com=True` and `fix_orientation=True` to default conversion from `qcio.Molecule` to `qcelemental.Molecule` objects so that qcel doesn't translate or rotate the molecule unsuspectingly without the user's consent. See default behaviors [here](https://github.com/MolSSI/QCElemental/blob/8e5a8cff52a6438ff9d6c1c6bbf1aeb4f02f12e1/qcelemental/models/molecule.py#L262-L281).
 
 ## [0.8.0] - 2024-01-12
 

--- a/qcio/qcel.py
+++ b/qcio/qcel.py
@@ -29,6 +29,11 @@ def to_qcel_input(prog_input: ProgramInput) -> Dict[str, Any]:
             "molecular_charge": prog_input.molecule.charge,
             "molecular_multiplicity": prog_input.molecule.multiplicity,
             "connectivity": prog_input.molecule.connectivity or None,
+            # Insane defaults, but they are the defaults in qcelemental
+            # Setting to True instead so qcel doesn't rotate or translate the molecule
+            # https://github.com/MolSSI/QCElemental/blob/8e5a8cff52a6438ff9d6c1c6bbf1aeb4f02f12e1/qcelemental/models/molecule.py#L262-L281  # noqa: E501
+            "fix_com": True,
+            "fix_orientation": True,
             "identifiers": prog_input.molecule.identifiers.model_dump(
                 exclude={"name_IUPAC", "name_common", "extras"}
             ),  # not on qcel model


### PR DESCRIPTION
…conversion so that qcel does not rotate or translate the input molecule unsuspectingly.