### PR TITLE
Update __all__ to only include ProgramOutput

### DIFF
--- a/src/qcdata/models/outputs.py
+++ b/src/qcdata/models/outputs.py
@@ -19,7 +19,7 @@ from .inputs import InputType as ProgramInputType
 from .structure import Structure
 from .utils import deprecated_class
 
-__all__ = ["ProgramOutput", "Results"]
+__all__ = ["ProgramOutput"]
 
 
 class ProgramOutput(QCDataBaseModel, Generic[ProgramInputType, DataType]):


### PR DESCRIPTION
Removed 'Results' from the exported symbols in outputs.py to fix import error.

Error from running test in package depending on qcdata:
_________________________________________________________________ ERROR collecting tests/test_autostore.py __________________________________________________________________
tests/test_autostore.py:8: in <module>
    from automol import Geometry
../automol/src/automol/__init__.py:5: in <module>
    from . import geom, qc, types
../automol/src/automol/qc/__init__.py:3: in <module>
    from . import structure
../automol/src/automol/qc/structure.py:4: in <module>
    from qcdata import Structure
.pixi/envs/dev-local/lib/python3.14/site-packages/qcdata/__init__.py:7: in <module>
    from .models import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^
.pixi/envs/dev-local/lib/python3.14/site-packages/qcdata/models/__init__.py:4: in <module>
    from .outputs import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'qcdata.models.outputs' has no attribute 'Results'